### PR TITLE
fix/types

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,7 @@
             </ion-list-header>
 
             <ion-menu-toggle
-              auto-hide="false"
+              :auto-hide=false
               v-for="(p, i) in appPages"
               :key="i"
             >
@@ -24,7 +24,7 @@
                 router-direction="root"
                 :router-link="p.url"
                 lines="none"
-                detail="false"
+                :detail=false
                 class="hydrated"
                 :class="{ selected: selectedIndex === i }"
               >

--- a/src/views/SearchList.vue
+++ b/src/views/SearchList.vue
@@ -7,7 +7,7 @@
         <ion-toolbar>
           <ion-searchbar
             animated
-            debounce="500"
+            :debounce=500
             show-cancel-button="focus"
             v-model="searchQuery"
           ></ion-searchbar>
@@ -17,14 +17,14 @@
         <ion-list>
           <ion-item
             v-for="value in searchResults()"
-            :key="value"
+            :key=getLoopKey(value)
             @click="confirm(value)"
             >{{ getValue(value) }}</ion-item
           >
         </ion-list>
         <ion-fab vertical="bottom" horizontal="end" slot="fixed">
           <ion-fab-button
-            activated="true"
+            :activated=true
             @click="cancel()"
           ></ion-fab-button>
         </ion-fab>
@@ -106,11 +106,15 @@
           return item;
         }
       };
+      const getLoopKey = (value: Record<string, any>) => {
+        return value[props.contentKey];
+      }
       const confirm = (value: any) => modalController.dismiss(value);
       const cancel = () => modalController.dismiss();
       return {
         confirm,
         cancel,
+        getLoopKey,
         getValue,
         searchQuery,
         searchResults,


### PR DESCRIPTION
**Descriptive Title**
Correct the directive attribute types to pass build step

**Changes**
Due to a stricter lint step, HTML components must use the v-bind directive annotation (v-bind:name, or simply :name) to treat the value as a literal rather than a string. So a property like `activated` that takes a boolean must be used as `:activated=true` or else the `true` is treated as a string, which causes the linter to fail when it looks for a boolean. Alternatively, a boolean property can be passed and skip the v-bind directive, but that's more work when you just need a `true` value.
